### PR TITLE
Deploy Lambda code through S3.

### DIFF
--- a/cloudformation/parameters.json
+++ b/cloudformation/parameters.json
@@ -10,6 +10,16 @@
     "UsePreviousValue": false
   },
   {
+    "ParameterKey": "S3DeploymentBucketName",
+    "ParameterValue": "andlytle-deployments",
+    "UsePreviousValue": false
+  },
+  {
+    "ParameterKey": "S3DeploymentFileKey",
+    "ParameterValue": "/lambda/my-project.zip",
+    "UsePreviousValue": false
+  },
+  {
     "ParameterKey": "ScheduleExpression",
     "ParameterValue": "rate(24 hours)",
     "UsePreviousValue": false

--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -19,6 +19,9 @@ Parameters:
   Runtime:
     Type: String
     Description: Runtime for the function; e.g. python2.7
+    AllowedValues:
+        - python2.7
+        - python3.6
 
   Timeout:
     Type: Number
@@ -27,6 +30,17 @@ Parameters:
   MemorySize:
     Type: Number
     Description: Memory for the function in MB
+    MinValue: 128
+    MaxValue: 1536
+
+  S3DeploymentBucketName:
+    Type: String
+    Description: S3 Bucket name to deploy code through.
+    Default: ''
+
+  S3DeploymentFileKey:
+    Type: String
+    Description: S3 key to use when deploying the zip file for this Lambda function.
 
 Conditions:
   HasSchedule:
@@ -45,20 +59,8 @@ Resources:
     DependsOn: [ LambdaFunctionExecutionRole ]
     Properties:
       Code:
-        ZipFile:
-          "Fn::Sub": |
-            import json
-            import logging
-
-            logging.basicConfig()
-            logger = logging.getLogger(__name__)
-            logger.setLevel(logging.INFO)
-
-            def handler(event, context):
-                logger.info('Event: ' + json.dumps(event))
-                logger.info('Context: ' + str(dir(context)))
-                return {'message': 'This is placeholder code! Replace me!'}
-
+        S3Bucket: !Ref S3DeploymentBucketName
+        S3Key: !Ref S3DeploymentFileKey
       Role: { "Fn::GetAtt": [ LambdaFunctionExecutionRole, Arn ] }
       Timeout: { Ref: Timeout }
       Handler: index.handler
@@ -68,7 +70,6 @@ Resources:
         Variables:
           EnvironmentName: { Ref: EnvironmentName }
           ProjectName: { Ref: ProjectName }
-
 
   LambdaFunctionExecutionRole:
     Type: AWS::IAM::Role

--- a/config.yaml
+++ b/config.yaml
@@ -22,4 +22,3 @@ env:
 # parameterstore_name: /$ProjectName/$EnvironmentName/name
 # parameterstore_bar: other.key.goes.here
 # parameterstore_baz: this.one.has.an.$EnvironmentName
-

--- a/index.py
+++ b/index.py
@@ -7,29 +7,9 @@ from utils.helpers import Helpers
 from utils.config import configuration
 
 
-def setup_logging(request_id, level=logging.INFO):
-    """Creates the logging formatter.
-
-    Args:
-        request_id: (str) The id of the execution context (i.e. the Lambda execution ID).
-        level: logging level to use.
-    """
-    logger = logging.getLogger()
-    logger.info('Setting up logging')
-    console_handler = logging.StreamHandler()
-    formatter = logging.Formatter(
-        '[%(levelname)s] %(asctime)s {0} [%(module)s:%(lineno)d]: %(message)s'.format(request_id))
-    console_handler.setFormatter(formatter)
-
-    logger.handlers = []  # Get rid of any default handlers (Lambda apparently adds one).
-    logger.addHandler(console_handler)
-    logger.setLevel(level)
-    return logger
-
-
 def handler(event, context):
     """Entry point for the Lambda function."""
-    logger = setup_logging(context.aws_request_id)
+    logger = Helpers.setup_logging(context.aws_request_id)
     config = configuration()
 
     pprint.pprint(config)

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,3 +3,4 @@ pytest==2.9.1
 mock==2.0.0
 awscli
 boto3
+jq

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,30 @@
+import mock
+import unittest
+from mock import patch, Mock, MagicMock
+import boto3
+from botocore.stub import Stubber
+
+import sys
+sys.path.append("..")
+import index
+
+
+class TestHandler(unittest.TestCase):
+    @mock.patch('index.Helpers.aws_account_id')
+    def test_handler(self, aws_account_id):
+        """
+        Test the handler operates as expected.
+        """
+        test_event = MagicMock()
+        test_context = MagicMock()
+
+        aws_account_id.return_value = '1234567890'
+        index.handler(test_event, test_context)
+
+
+def main():
+    unittest.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/utils/test_utility.py
+++ b/tests/utils/test_utility.py
@@ -9,19 +9,17 @@ class TestHelpers(unittest.TestCase):
     @mock.patch('boto3.client')
     def testAwsAccountId(self, patched_boto):
         """Tests the output of Helpers.aws_account_id."""
-        patched_boto.return_value.describe_security_groups.return_value = {
-          'SecurityGroups': [{ 'OwnerId': '123456654321' }]
-        }
+        patched_boto.return_value.get_caller_identity.return_value = {
+            'Arn': 'arn:aws:iam::123456654321:user/dliggat' }
 
         # Query for the account id; first to generate, second for a cache hit.
-        self.assertEqual(Helpers.aws_account_id(), 123456654321)
-        self.assertEqual(Helpers.aws_account_id(), 123456654321)
+        self.assertEqual(Helpers.aws_account_id(), '123456654321')
+        self.assertEqual(Helpers.aws_account_id(), '123456654321')
 
         # We should only ever the boto code once; the account value should
         # be memoized in the class after the initial invocation.
-        patched_boto.assert_called_once_with('ec2')
-        patched_boto.return_value.describe_security_groups.assert_called_once_with(
-            GroupNames=['default'])
+        patched_boto.assert_called_once_with('sts')
+        patched_boto.return_value.get_caller_identity.assert_called_once_with()
 
 
 def main():

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,3 +1,4 @@
+import logging
 import boto3
 
 
@@ -13,3 +14,23 @@ class Helpers(object):
             caller_data = boto3.client('sts').get_caller_identity()
             cls._aws_account_id = caller_data['Arn'].split(':')[4]
         return cls._aws_account_id
+
+    @staticmethod
+    def setup_logging(request_id, level=logging.INFO):
+        """Creates the logging formatter.
+
+        Args:
+            request_id: (str) The id of the execution context (i.e. the Lambda execution ID).
+            level: logging level to use.
+        """
+        logger = logging.getLogger()
+        logger.info('Setting up logging')
+        console_handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            '[%(levelname)s] %(asctime)s {0} [%(module)s:%(lineno)d]: %(message)s'.format(request_id))
+        console_handler.setFormatter(formatter)
+
+        logger.handlers = []  # Get rid of any default handlers (Lambda apparently adds one).
+        logger.addHandler(console_handler)
+        logger.setLevel(level)
+        return logger


### PR DESCRIPTION
The major change is here is that I'm using S3 to deploy changes to the Lambda code, and I've removed the ZipFile code in Cloudformation. I found this duplication confusing when I first started using the toolkit. It will avoid future issues with Code size as well.

Changes to the Makefile:
- Pull S3 Bucket/Key from `cloudformation/parameters.json`
- Removed the `-stack` suffix from the Stack Name because it's redundant 
- Added checks to confirm user is authenticated with AWS, and removed the requirement for manually inputting an ARN.
- Swapped out `deploy` target for `update`, which runs a build and uploads the new code to S3, then updates Lambda accordingly. This is more consistent with what we built in Cloudformation. I found the previous model caused the CFN template and stack to become inconsistent when you updated the Lambda code, so I think this makes more sense.
- Added a default test_index.py to test the handler
- Moved the setup_logging code to be a static member in helpers.Helpers, making the index.py into a cleaner starting point for the project code.

So now the workflow is `make create-stack` to start, and then `make update` whenever you have made changes to the Lambda code in index.py.

I've made a lot of opinionated changes here, so I'm very open to debate on any of these points. Except the removal of the -stack suffix (ง'̀-'́)ง 